### PR TITLE
Fix restart-ts for multiple listeners

### DIFF
--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -671,6 +671,7 @@ gst_inter_pipe_src_push_buffer (GstInterPipeIListener * iface,
         GST_TIME_ARGS (GST_BUFFER_PTS (buffer)));
   } else if (GST_INTER_PIPE_SRC_RESTART_TIMESTAMP == src->stream_sync) {
     /* Remove the incoming timestamp to be generated according this basetime */
+    buffer = gst_buffer_make_writable (buffer);
     GST_BUFFER_PTS (buffer) = GST_CLOCK_TIME_NONE;
     GST_BUFFER_DTS (buffer) = GST_CLOCK_TIME_NONE;
   }


### PR DESCRIPTION
Fix invalid PTS/DTS for the case where there are multiple listeners with different stream-sync settings: fx one with restart-ts and the other with passthrough-ts.
The restart-ts branch was invalidating the PTS and DTS which would also affect the other branch since the buffer wasn't ensured as writable.