### PR TITLE
Fix event queue handling

### DIFF
--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -473,13 +473,14 @@ gst_inter_pipe_src_create (GstBaseSrc * base, guint64 offset, guint size,
       "Dequeue buffer %p with timestamp (PTS) %" GST_TIME_FORMAT, *buf,
       GST_TIME_ARGS (GST_BUFFER_PTS (*buf)));
 
-  if (!g_queue_is_empty (src->pending_serial_events)) {
+  while (!g_queue_is_empty (src->pending_serial_events)) {
     guint curr_bytes;
     /*Pending Serial Events Queue */
     serial_event = g_queue_peek_head (src->pending_serial_events);
 
     GST_DEBUG_OBJECT (src,
-        "Got event with timestamp %" GST_TIME_FORMAT,
+        "Got event %s with timestamp %" GST_TIME_FORMAT,
+        GST_EVENT_TYPE_NAME (serial_event),
         GST_TIME_ARGS (GST_EVENT_TIMESTAMP (serial_event)));
 
     curr_bytes = gst_app_src_get_current_level_bytes (GST_APP_SRC (src));
@@ -495,6 +496,7 @@ gst_inter_pipe_src_create (GstBaseSrc * base, guint64 offset, guint size,
       GST_DEBUG_OBJECT (src, "Event %s timestamp is greater than the "
           "buffer timestamp, can't send serial event yet",
           GST_EVENT_TYPE_NAME (serial_event));
+          break;
     }
   }
 


### PR DESCRIPTION
Send all queued events with "timestamp < buffer timestamp" instead of just the 1st one before sending the buffer.

Only the 1st event of the event queue with "timestamp < buffer timestamp" was being send before the buffer.
But there could be several events in the queue that should sent before the buffer.

Fixes https://github.com/RidgeRun/gst-interpipe/issues/96

The segment event was not being handled properly when using x264enc + mpegtsmux together with interpipesrc/sink.
Which was causing 2 segment to be delivered to the mpegtsmux:
1st one generated by the interpipesrc (starting from zero) because no segment existed.
2nd coming from the x264 encoder (correcting the 1000 hours offset added by the encoder).

The 1st segment resulted in all subsequent DTS being seen as invalid (backwards) by the muxer.

This happened because the event queue contained the following: stream-start, segment, tag, tag, tag.
All with timestamp 0.
But only the stream-start was sent, then the 1st buffer, then the segment.
Which caused the DTS issues.