### PR TITLE
Fix segment handling in interpipesrc

### DIFF
--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -491,7 +491,22 @@ gst_inter_pipe_src_create (GstBaseSrc * base, guint64 offset, guint size,
           GST_EVENT_TYPE_NAME (serial_event));
 
       serial_event = g_queue_pop_head (src->pending_serial_events);
-      gst_pad_push_event (srcpad, serial_event);
+      
+      if (GST_EVENT_TYPE (serial_event) == GST_EVENT_SEGMENT) {
+          const GstSegment *segment = NULL;
+
+          gst_event_parse_segment (serial_event, &segment);
+          g_assert (segment != NULL);
+
+          GST_DEBUG_OBJECT (src,
+              "Update new segment %" GST_PTR_FORMAT, serial_event);
+          if (!gst_base_src_new_segment (base, segment)) {
+            GST_ERROR_OBJECT (src,
+                "Couldn't set new segment %" GST_PTR_FORMAT, serial_event);
+          }
+      } else {
+          gst_pad_push_event (srcpad, serial_event);
+      }
     } else {
       GST_DEBUG_OBJECT (src, "Event %s timestamp is greater than the "
           "buffer timestamp, can't send serial event yet",


### PR DESCRIPTION
It was missing something like what is done in appsrc->create(): https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/blob/master/gst-libs/gst/app/gstappsrc.c#L1676

Otherwise it will generate an extra default segment (which is incorrect if x264enc is present)

Related to https://github.com/RidgeRun/gst-interpipe/issues/96